### PR TITLE
changed iOS titanium SDK path to a relative one instead absolute

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ Register your module with your application by editing `tiapp.xml` and adding you
 Example:
 
 <modules>
-	<module version="0.1">com.sttts.exit</module>
+	<module version="1.0.0">com.sttts.exit</module>
 </modules>
 
 When you run your project, the compiler will combine your module along with its dependencies

--- a/iphone/titanium.xcconfig
+++ b/iphone/titanium.xcconfig
@@ -10,7 +10,7 @@ TITANIUM_SDK_VERSION = 3.5.0.GA
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = /Users/sts/Library/Application Support/Titanium/mobilesdk/osx/3.5.0.GA
+TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/3.5.0.GA
 TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
 TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
 TITANIUM_BASE_SDK3 = "$(TITANIUM_SDK)/iphone/include/JavaScriptCore"


### PR DESCRIPTION
changed the sdk path from an absolute to a relative so anyone can compile it.

I see this mistake a lot and it's technically Appcelerator's fault for making the module SDK have this behavior by default.

I will do another pull request for android later.
